### PR TITLE
Rebuild for new compilers (again)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: eb00f951bbe36e933d16de520db44acf93e9becf6e0182e391c1c7f98441972b
 
 build:
-  number: 1003
+  number: 2003
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Due to an issue in ci-scripts, which has been resolved, there was a bad version
number bump in the main channel for this package.

This PR will increase the build number for the new compiler's build by 1000,
allowing them to take precedence when the new compilers are merged with the
main branch.